### PR TITLE
Add action:sento intent to plugin.xml

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -112,6 +112,15 @@
             </provider>
         </config-file>
 
+        <config-file target="AndroidManifest.xml" parent="/*">
+            <queries>
+                <intent>
+                    <action android:name="android.intent.action.SENDTO" />
+                    <data android:scheme="mailto" />
+                </intent>
+            </queries>
+        </config-file>
+  
         <source-file
             src="src/android/xml/emailcomposer_provider_paths.xml"
             target-dir="res/xml" />


### PR DESCRIPTION
With Android11, queryintentactivities api doesn't return a list of email client unless the intent is set in AndroidManifest. This is because of Android 11 package visibility feature. reference - https://devblogs.microsoft.com/xamarin/android-11-package-visibility/